### PR TITLE
fix(nepal): weekly menu moved

### DIFF
--- a/modules/nepal.php
+++ b/modules/nepal.php
@@ -3,7 +3,7 @@
 class Nepal extends LunchMenuSource
 {
 	public $title = 'Nepal';
-	public $link = 'https://nepalbrno.cz/poledni.php';
+	public $link = 'https://nepalbrno.cz/NepalBrno/poledni.php';
 	public $icon = 'nepal';
 
 	public function getTodaysMenu($todayDate, $cacheSourceExpires)


### PR DESCRIPTION
NepalBrno moved their weekly menu

`obed.cucin.eu`:
<img width="592" height="149" alt="image" src="https://github.com/user-attachments/assets/5d1a4056-2d5d-4436-8312-9e587eeff94a" />
 
 fixed: 
<img width="1022" height="496" alt="image" src="https://github.com/user-attachments/assets/5147cb88-c636-407a-81f5-a5f30b0eeef1" />
