### PR TITLE
klubcestovatelu: fix soup parsing

### DIFF
--- a/modules/klubcestovatelu.php
+++ b/modules/klubcestovatelu.php
@@ -31,11 +31,10 @@ class KlubCestovatelu extends LunchMenuSource
 
 			$soup = $day->next_sibling();
 			$menu = $soup->next_sibling();
-			while ($menu->tag != "ol" && $menu) {
+			while ($menu && $menu->tag != "ol") {
 				$menu = $menu->next_sibling();
 			}
 
-			$soup = $soup->find("p", 0);
 			if ($soup && $soup->tag == 'p' && trim(str_replace("\xc2\xa0", ' ', html_entity_decode($soup->plaintext))) != NULL) {
 				$result->dishes[] = new Dish(html_entity_decode($soup->plaintext));
 			}


### PR DESCRIPTION
## Summary
- Keep existing parser flow and fix soup extraction to read text directly from the sibling `p` node.

## Why
- The previous implementation called `find("p", 0)` on a node that was already the soup paragraph, which produced an empty soup in practice.

## Scope
- Changed file: `modules/klubcestovatelu.php`