### PR TITLE
Fix parsing of Charlie's, Klub cestovatelů and Menza

### DIFF
--- a/modules/charlies.php
+++ b/modules/charlies.php
@@ -18,39 +18,68 @@ class Charlies extends LunchMenuSource
 		$today = get_czech_day(date('w', $todayDate));
 
 		$content = $cached['html']->find("div.entry-content", 0);
-		if (!$content) {
-			throw new ScrapingFailedException("div.entry-content not found");
-		}
+		$tables = $content? $content->find("table.menu-one-day") : array();
 
-		$tables = $content->find("table.menu-one-day");
-		if (!$tables) {
-			throw new ScrapingFailedException("table.menu-one-day not found");
-		}
-
-		foreach ($tables as $table) {
-			$title = $this->normalizeText($table->find("th.table-title", 0)->plaintext);
-			$title_lc = mb_strtolower($title);
-
-			if (strpos($title_lc, $today) !== FALSE) {
-				// todays menu
-				$this->processTable($result, null, $table);
-
-			} else {
-				$isOtherDay = false;
-				foreach(get_all_czech_days() as $day) {
-					if (strpos($title_lc, $day) !== FALSE) {
-						$isOtherDay = true;
-						break;
-					}
-				}
-
-				if (!$isOtherDay) {
-					$this->processTable($result, $title, $table);
-				}
+		if ($tables) {
+			foreach ($tables as $table) {
+				$title = $this->normalizeText($table->find("th.table-title", 0)->plaintext);
+				$this->processMenuBlock($result, $today, $title, $table, true);
 			}
+
+			return $result;
+		}
+
+		$menus = $cached['html']->find("div.menu-one-day");
+		if (!$menus) {
+			throw new ScrapingFailedException("menu-one-day not found");
+		}
+
+		foreach ($menus as $menu) {
+			$title = '';
+			$parent = $menu->parent();
+			$titleElement = $parent? $parent->find("h2", 0) : null;
+			if ($titleElement) {
+				$title = $this->normalizeText($titleElement->plaintext);
+			}
+			$this->processMenuBlock($result, $today, $title, $menu, false);
 		}
 
 		return $result;
+	}
+
+	protected function processMenuBlock(&$result, $today, $title, $block, $isTable)
+	{
+		$title_lc = mb_strtolower($title);
+		if ($title_lc == 'nabídka baru') {
+			return;
+		}
+
+		if (strpos($title_lc, $today) !== FALSE) {
+			// todays menu
+			$this->processDishes($result, null, $block, $isTable);
+
+		} else {
+			$isOtherDay = false;
+			foreach(get_all_czech_days() as $day) {
+				if (strpos($title_lc, $day) !== FALSE) {
+					$isOtherDay = true;
+					break;
+				}
+			}
+
+			if (!$isOtherDay) {
+				$this->processDishes($result, $title, $block, $isTable);
+			}
+		}
+	}
+
+	protected function processDishes(&$result, $group, $block, $isTable)
+	{
+		if ($isTable) {
+			$this->processTable($result, $group, $block);
+		} else {
+			$this->processDivMenu($result, $group, $block);
+		}
 	}
 
 	protected function processTable(&$result, $group, $table)
@@ -67,8 +96,43 @@ class Charlies extends LunchMenuSource
 		}
 	}
 
+	protected function processDivMenu(&$result, $group, $menu)
+	{
+		foreach ($menu->children() as $row) {
+			if ($row->tag != 'div') {
+				continue;
+			}
+
+			$columns = array();
+			foreach ($row->children() as $column) {
+				if ($column->tag == 'div') {
+					$columns[] = $this->normalizeText($column->plaintext);
+				}
+			}
+
+			if (count($columns) < 2) {
+				continue;
+			}
+
+			$label = count($columns) > 2? array_shift($columns) : '';
+			$price = array_pop($columns);
+			$what = implode(' ', $columns);
+			if ($what == '' || $price == '') {
+				continue;
+			}
+
+			if (preg_match('/^Menu\s+\d+$/ui', $label)) {
+				$what = "$label: $what";
+			}
+
+			$result->dishes[] = new Dish($what, $price, NULL, $group);
+		}
+	}
+
 	protected function normalizeText($text)
 	{
-		return trim(html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+		$text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+		$text = preg_replace('/\s+/u', ' ', $text);
+		return trim($text);
 	}
 }

--- a/modules/klubcestovatelu.php
+++ b/modules/klubcestovatelu.php
@@ -12,43 +12,73 @@ class KlubCestovatelu extends LunchMenuSource
 		$result = new LunchMenuResult($cached['stored']);
 
 		$content = $cached['html']->find("div.entry-content", 0);
-
-		$regexp = '(' . get_czech_day(date('w', $todayDate)) . '\s+' . date('j', $todayDate) . '\.)ui';
-
-		$pricearr = array();
-		$prices = $content->find("p strong", 0);
-		if ($prices && !$prices->prev_sibling() && !$prices->next_sibling()) {
-			$prices = explode('/', $prices->plaintext);
-			foreach ($prices as $price) {
-				$price = explode('&#8211;', $price);
-				$pricearr[] = trim(ltrim(str_replace("&nbsp;", "", $price[1]), "–"));
-			}
+		if (!$content) {
+			throw new ScrapingFailedException("div.entry-content not found");
 		}
 
-		$days = $content->find("h3");
-		foreach ($days as $day) {
-			if (!preg_match($regexp, $day->plaintext)) continue;
-
-			$soup = $day->next_sibling();
-			$menu = $soup->next_sibling();
-			while ($menu && $menu->tag != "ol") {
-				$menu = $menu->next_sibling();
-			}
-
-			if ($soup && $soup->tag == 'p' && trim(str_replace("\xc2\xa0", ' ', html_entity_decode($soup->plaintext))) != NULL) {
-				$result->dishes[] = new Dish(html_entity_decode($soup->plaintext));
-			}
-
-			if ($menu && $menu->tag == 'ol') {
-				$num = 1;
-				foreach ($menu->find('li') as $dish) {
-					$what = html_entity_decode($dish->plaintext);
-					$price = isset($pricearr[$num-1]) ? $pricearr[$num-1] : NULL;
-					$result->dishes[] = new Dish($what, $price, NULL, NULL, $num++);
-				}
-			}
+		$iframe = $content->find("iframe#menu-frame", 0);
+		if (!$iframe) {
+			throw new ScrapingFailedException("iframe#menu-frame not found");
 		}
 
+		$iframeUrl = html_entity_decode($iframe->src, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+		if (strpos($iframeUrl, '//') === 0) {
+			$iframeUrl = 'https:' . $iframeUrl;
+		} elseif (strpos($iframeUrl, 'http') !== 0) {
+			$iframeUrl = rtrim($this->link, '/') . '/' . ltrim($iframeUrl, '/');
+		}
+
+		$menu = cache_get_html($this->title . ' iframe', $iframeUrl, $cacheSourceExpires);
+		if (!$menu['html']) {
+			throw new ScrapingFailedException("iframe menu not loaded");
+		}
+
+		$this->processEmbeddedMenu($result, $menu['html'], $todayDate);
 		return $result;
+	}
+
+	protected function processEmbeddedMenu(&$result, $html, $todayDate)
+	{
+		$dayName = get_czech_day(date('w', $todayDate));
+		$dayBlock = null;
+		foreach ($html->find('div.day-block') as $block) {
+			$name = $this->normalizeText($block->find('span.day-name', 0)->plaintext);
+			if (mb_strtolower($name) == $dayName) {
+				$dayBlock = $block;
+				break;
+			}
+		}
+
+		if (!$dayBlock) {
+			throw new ScrapingFailedException("today's day-block not found");
+		}
+
+		$prices = array();
+		foreach ($html->find('span.price-item strong') as $priceItem) {
+			$text = $this->normalizeText($priceItem->plaintext);
+			if (preg_match('/Menu\s+č\.\s*([0-9]+)\s*[–-]\s*(.+)$/ui', $text, $m)) {
+				$prices[(int)$m[1]] = trim($m[2]);
+			}
+		}
+
+		$soup = $dayBlock->find('span.soup-name', 0);
+		if ($soup) {
+			$result->dishes[] = new Dish($this->normalizeText($soup->plaintext));
+		}
+
+		foreach ($dayBlock->find('li.dish-item') as $dish) {
+			$number = $this->normalizeText($dish->find('span.dish-num', 0)->plaintext);
+			$number = trim($number, '.');
+			$what = $this->normalizeText($dish->find('span.dish-name', 0)->plaintext);
+			$price = isset($prices[(int)$number])? $prices[(int)$number] : NULL;
+			$result->dishes[] = new Dish($what, $price, NULL, NULL, $number);
+		}
+	}
+
+	protected function normalizeText($text)
+	{
+		$text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+		$text = preg_replace('/\s+/u', ' ', $text);
+		return trim($text);
 	}
 }

--- a/modules/menza.php
+++ b/modules/menza.php
@@ -8,15 +8,20 @@ class Menza extends LunchMenuSource {
 
 	public function getTodaysMenu($todayDate, $cacheSourceExpires)
 	{
-		$cached = $this->downloadHtml($cacheSourceExpires);
+		$cached = $this->downloadRaw($cacheSourceExpires);
 		$result = new LunchMenuResult($cached['stored']);
 		$group = null;
 
-		$table = $cached['html']->find("table#m5", 0);
-
-		if (!$table) {
+		if (!preg_match('/<table\b[^>]*\bid=["\']m5["\'][^>]*>.*?<\/table>/is', $cached['contents'], $m)) {
 			throw new ScrapingFailedException("table#m5 was not found");
 		}
+
+		$tableHtml = str_get_html($m[0]);
+		if (!$tableHtml) {
+			throw new ScrapingFailedException("table#m5 could not be parsed");
+		}
+
+		$table = $tableHtml->find("table#m5", 0);
 
 		$mapping = array(
 			"td.levy" => "type",
@@ -28,13 +33,25 @@ class Menza extends LunchMenuSource {
 
 		foreach ($table->find("tr") as $i => $row) {
 
-			$values = array_fill_keys(array_keys($mapping), 0);
+			$values = array(
+				"type" => "",
+				"name" => "",
+				"priceStudent" => "",
+				"priceEmployee" => "",
+				"priceExternal" => "",
+			);
 			foreach ($mapping as $selector => $key) {
-				$element = $row->find($selector);
+				if ($key == 'name') {
+					$element = $this->findCzechName($row);
+				} else {
+					$element = $row->find($selector, 0);
+				}
 				if ($element) {
-					$value = $element[0]->plaintext;
-					$value = preg_replace('/&nbsp;/i', ' ', $value);
-					$values[$key] = $value;
+					$text = $element->plaintext;
+					if ($key == 'name') {
+						$text = preg_replace('/<small\b[^>]*>.*?<\/small>/is', '', $element->innertext);
+					}
+					$values[$key] = $this->normalizeText($text);
 				}
 			}
 
@@ -57,10 +74,31 @@ class Menza extends LunchMenuSource {
 				"Externí stravník" => $values["priceExternal"],
 			);
 
-			$result->dishes[] = new Dish($values["name"], $price, null, $group);
+			$result->dishes[] = new Dish($values["name"], $price, '', $group, '');
 		}
 
 		return $result;
 
+	}
+
+	protected function findCzechName($row)
+	{
+		$fallback = null;
+		foreach ($row->find('td.levyjid') as $element) {
+			if (!$fallback) {
+				$fallback = $element;
+			}
+			if (strpos($element->class, 'jjjaz1jjj') !== FALSE) {
+				return $element;
+			}
+		}
+		return $fallback;
+	}
+
+	protected function normalizeText($text)
+	{
+		$text = strip_tags(html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+		$text = preg_replace('/\s+/u', ' ', $text);
+		return trim($text);
 	}
 }


### PR DESCRIPTION
## Summary
- Fix Charlie's Mill parsing for the new `div.menu-one-day` layout and skip `Nabídka baru`.
- Fix Klub cestovatelů parsing by reading the embedded iframe menu.
- Fix Menza parsing to extract the oversized source table first, prefer the Czech dish cell, strip allergen suffixes, and normalize values.

## Why
- Charlie's Mill no longer serves the old `entry-content` table layout.
- Klub cestovatelů moved the actual menu into `iframe#menu-frame`.
- Menza HTML now exceeds the parser size limit, and rows include multiple `td.levyjid` language cells plus allergen markup in dish names.

## Scope
- Changed files: `modules/charlies.php`, `modules/klubcestovatelu.php`, `modules/menza.php`